### PR TITLE
Disable HTML escaping (zeek chokes on unicode escape sequences in JSO…

### DIFF
--- a/pkg/encoding/data.go
+++ b/pkg/encoding/data.go
@@ -373,10 +373,18 @@ func (d *Data) MarshalJSON() ([]byte, error) {
 			"data":       fmt.Sprintf("%d/%s", serv.Port, serv.Protocol.String()),
 		})
 	default:
-		return json.Marshal(map[string]interface{}{
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+
+		if err := enc.Encode(map[string]interface{}{
 			"@data-type": d.DataType,
 			"data":       d.DataValue,
-		})
+		}); err != nil {
+			return nil, err
+		}
+
+		return buf.Bytes(), nil
 	}
 }
 

--- a/pkg/encoding/data_test.go
+++ b/pkg/encoding/data_test.go
@@ -3,6 +3,7 @@
 package encoding
 
 import (
+	"bytes"
 	"net"
 	"reflect"
 	"testing"
@@ -391,5 +392,24 @@ func Test_formatTimespan(t *testing.T) {
 				t.Errorf("formatTimespan() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_encodeHTMLEntity(t *testing.T) {
+	stringWithHTMLEntity := Data{
+		DataType:  TypeString,
+		DataValue: "<ohai>",
+	}
+
+	want := []byte(`{"@data-type":"string","data":"<ohai>"}`)
+
+	buf, err := stringWithHTMLEntity.MarshalJSON()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(buf, want) != 0 {
+		t.Errorf("expected %s got %s", want, buf)
 	}
 }


### PR DESCRIPTION
…N strings)

See https://github.com/zeek/broker/issues/457