### PR TITLE
Another "none" encoding bug fix, and fixing a unit test

### DIFF
--- a/pkg/encoding/data.go
+++ b/pkg/encoding/data.go
@@ -372,6 +372,8 @@ func (d *Data) MarshalJSON() ([]byte, error) {
 			"@data-type": d.DataType,
 			"data":       fmt.Sprintf("%d/%s", serv.Port, serv.Protocol.String()),
 		})
+	case TypeNone:
+		return []byte(`{"@data-type":"none","data":{}}`), nil
 	default:
 		buf := &bytes.Buffer{}
 		enc := json.NewEncoder(buf)

--- a/pkg/encoding/data_test.go
+++ b/pkg/encoding/data_test.go
@@ -413,3 +413,22 @@ func Test_encodeHTMLEntity(t *testing.T) {
 		t.Errorf("expected %s got %s", want, buf)
 	}
 }
+
+func Test_None(t *testing.T) {
+	none := Data{
+		DataType:  TypeNone,
+		DataValue: nil,
+	}
+
+	want := []byte(`{"@data-type":"none","data":{}}`)
+
+	buf, err := none.MarshalJSON()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(buf, want) != 0 {
+		t.Errorf("expected %s got %s", want, buf)
+	}
+}

--- a/pkg/encoding/data_test.go
+++ b/pkg/encoding/data_test.go
@@ -401,7 +401,7 @@ func Test_encodeHTMLEntity(t *testing.T) {
 		DataValue: "<ohai>",
 	}
 
-	want := []byte(`{"@data-type":"string","data":"<ohai>"}`)
+	want := []byte(`{"@data-type":"string","data":"<ohai>"}` + "\n")
 
 	buf, err := stringWithHTMLEntity.MarshalJSON()
 

--- a/pkg/encoding/helpers.go
+++ b/pkg/encoding/helpers.go
@@ -138,6 +138,6 @@ func Table(value map[Data]Data) Data {
 func None() Data {
 	return Data{
 		DataType:  TypeNone,
-		DataValue: make(map[string]interface{}),
+		DataValue: nil,
 	}
 }

--- a/pkg/encoding/helpers_test.go
+++ b/pkg/encoding/helpers_test.go
@@ -325,7 +325,7 @@ func TestData_Event(t *testing.T) {
 func TestData_None(t *testing.T) {
 	wantData := Data{
 		DataType:  "none",
-		DataValue: make(map[string]interface{}),
+		DataValue: nil,
 	}
 
 	gotData := None()


### PR DESCRIPTION
The "none" type encoding was previously fixed for the `None()` helper in https://github.com/corelight/go-zeek-broker-ws/commit/d2d127f754eadfdd3dbb50676ec1b2f047f41e06 by explicitly encoding an empty map instead of setting it to nil (which encodes to "null").

Since we decode the value from `{}` to `nil`, that means re-encoding such `Data` was a second path to the previous defect. This now solved via a special `TypeNone` case in the encoder and includes a unit test.

This change also removes the need for the previous fix, so the `TestData_None` unit test has been updated to expect nil instead of an empty map.

Both paths should now be a tiny bit faster since the JSON-encoding for "none" data type is hard-coded (doesn't rely on `encoding/json`) and we don't have to allocate empty maps.

The other commit fixes the unit test added via 5275a5234df323dda69e997a6ec0673d405bb75a. I honestly don't know how I botched that one ☹️ 